### PR TITLE
Make entries in  scopedSlots optional

### DIFF
--- a/types/base.d.ts
+++ b/types/base.d.ts
@@ -36,12 +36,12 @@ export type EventHandlers<E> = {
 export type TsxComponentAttrs<TProps = {}, TEvents = {}, TScopedSlots = {}> =
   | ({ props: TProps } & Partial<TProps> &
       KnownAttrs & {
-        scopedSlots?: ScopedSlots<TScopedSlots>;
+        scopedSlots?: ScopedSlots<TScopedSlots> | { [key:string] : any };
       } & EventHandlers<TEvents> &
       VueTsx.ComponentAdditionalAttrs)
   | (TProps &
       KnownAttrs & {
-        scopedSlots?: ScopedSlots<TScopedSlots>;
+        scopedSlots?: ScopedSlots<TScopedSlots> | { [key:string] : any };
       } & EventHandlers<TEvents> &
       VueTsx.ComponentAdditionalAttrs);
 


### PR DESCRIPTION
With the current type definition TypeScript assumes that *all* scoped slots have to be provided. This makes it impossible to pass only one of multiple scoped slots.

This PR adjusts scopedSlots type to allow passing **one or more** scoped slots.

### Before:

Due to the current type definition TypeScript complains that **some of the slots** are missing. This means, according to TypeScript you always have to pass **all** scoped slots. It is impossible to pass only one or some of them.

<img width="535" alt="bildschirmfoto 2018-11-12 um 15 46 23" src="https://user-images.githubusercontent.com/1009726/48354492-309cdb80-e692-11e8-9e40-8fb9b4560018.png">

### After:
ommiting some or all scoped slots is not an error anymore:

<img width="333" alt="bildschirmfoto 2018-11-12 um 15 48 58" src="https://user-images.githubusercontent.com/1009726/48354645-7f4a7580-e692-11e8-988c-c15246bf202b.png">

but passing some incompatible type still leads to an error message:

<img width="538" alt="bildschirmfoto 2018-11-12 um 15 50 30" src="https://user-images.githubusercontent.com/1009726/48354763-c6d10180-e692-11e8-936a-19db6e627e91.png">


