### PR TITLE
Fix: types `[name: string]: any` to `name: any`

### DIFF
--- a/enable-check.d.ts
+++ b/enable-check.d.ts
@@ -10,7 +10,7 @@ declare global {
 
         interface IntrinsicElements extends base.IntrinsicElements {
             // allow unknown elements
-            [name: string]: any;
+            name: any;
 
             // builtin components
             transition: base.TsxComponentAttrs<builtin.TransitionProps>;


### PR DESCRIPTION
Hi.
Thank you for the awesome library!

I had an error in my project.

```
ERROR in {MY_PROJECT}/node_modules/vue-tsx-support/enable-check.d.ts
13:13 Duplicate string index signature.
    11 |         interface IntrinsicElements extends base.IntrinsicElements {
    12 |             // allow unknown elements
  > 13 |             [name: string]: any;
       |             ^
    14 | 
    15 |             // builtin components
    16 |             transition: base.TsxComponentAttrs<builtin.TransitionProps>;
Version: typescript 3.1.6
```