### PR TITLE
Fix type declaration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ there are some options to make it tsx-ready.
   import { Component, Prop } from "vue-property-decorator";
   import * as tsx from "vue-tsx-support";
 
-  type MyComponentProps {
+  type MyComponentProps = {
     text: string;
     important?: boolean;
   }


### PR DESCRIPTION
`type MyComponentProps {...}` gave error "`Parsing error: '=' expected`". Adding `=` fixed the issue.