### PR TITLE
#79: add 'file' attribute to InputHTMLAttributes interface

### DIFF
--- a/types/dom.d.ts
+++ b/types/dom.d.ts
@@ -169,6 +169,7 @@ export interface InputHTMLAttributes extends HTMLAttributes {
   crossorigin?: string;
   disabled?: boolean;
   form?: string;
+  files?: FileList;
   formaction?: string;
   formenctype?: string;
   formmethod?: string;


### PR DESCRIPTION
Fix #79

This PR will enable type completion for file uploading.