### PR TITLE
Add transition duration prop

### DIFF
--- a/types/builtin-components.d.ts
+++ b/types/builtin-components.d.ts
@@ -28,6 +28,7 @@ export interface TransitionPropsBase {
 
 export interface TransitionProps extends TransitionPropsBase {
   mode?: string;
+  duration?: number | { enter: number; leave: number };
 }
 
 export interface TransitionGroupProps extends TransitionPropsBase {


### PR DESCRIPTION
Adds `duration` prop for the `<transition />` component.

See [Explicit Transition Durations](https://vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations)

Should resolve this error:
```
Type '{ duration: number; }' is not assignable to type 'CombinedTsxComponentAttrs<TransitionProps, {}, {}, {}, {}, true>'.
  Property 'duration' does not exist on type 'CombinedTsxComponentAttrs<TransitionProps, {}, {}, {}, {}, true>'.ts(2322)
```